### PR TITLE
Handle all positional argument errors with PositionalArgumentError exception

### DIFF
--- a/src/command_bundle.cc
+++ b/src/command_bundle.cc
@@ -8,16 +8,16 @@
 #include <iostream> // std::cout
 
 #include "command.h"
+#include "error.h"
 #include "utils.h"
 
 auto sourcemeta::jsonschema::cli::bundle(
     const sourcemeta::core::Options &options) -> int {
 
   if (options.positional().size() < 1) {
-    std::cerr
-        << "error: This command expects a path to a schema. For example:\n\n"
-        << "  jsonschema bundle path/to/schema.json\n";
-    return EXIT_FAILURE;
+    throw sourcemeta::jsonschema::PositionalArgumentError(
+        "This command expects a path to a schema. For example:",
+        "  jsonschema bundle path/to/schema.json");
   }
 
   const std::filesystem::path schema_path{options.positional().front()};

--- a/src/command_compile.cc
+++ b/src/command_compile.cc
@@ -9,15 +9,15 @@
 #include <iostream> // std::cerr, std::cout
 
 #include "command.h"
+#include "error.h"
 #include "utils.h"
 
 auto sourcemeta::jsonschema::cli::compile(
     const sourcemeta::core::Options &options) -> int {
   if (options.positional().size() < 1) {
-    std::cerr
-        << "error: This command expects a path to a schema. For example:\n\n"
-        << "  jsonschema compile path/to/schema.json\n";
-    return EXIT_FAILURE;
+    throw sourcemeta::jsonschema::PositionalArgumentError(
+        "This command expects a path to a schema. For example:",
+        "  jsonschema compile path/to/schema.json");
   }
 
   const auto &schema_path{options.positional().at(0)};

--- a/src/command_decode.cc
+++ b/src/command_decode.cc
@@ -12,6 +12,7 @@
 #include <iostream>   // std::cout, std::endl
 
 #include "command.h"
+#include "error.h"
 #include "utils.h"
 
 static auto has_data(std::ifstream &stream) -> bool {
@@ -30,11 +31,10 @@ static auto has_data(std::ifstream &stream) -> bool {
 auto sourcemeta::jsonschema::cli::decode(
     const sourcemeta::core::Options &options) -> int {
   if (options.positional().size() < 2) {
-    std::cerr
-        << "error: This command expects a path to a binary file and an "
-           "output path. For example:\n\n"
-        << "  jsonschema decode path/to/output.binpack path/to/document.json\n";
-    return EXIT_FAILURE;
+    throw sourcemeta::jsonschema::PositionalArgumentError(
+        "This command expects a path to a binary file and an "
+        "output path. For example:",
+        "  jsonschema decode path/to/output.binpack path/to/document.json");
   }
 
   // TODO: Take a real schema as argument

--- a/src/command_encode.cc
+++ b/src/command_encode.cc
@@ -13,16 +13,16 @@
 #include <iostream>   // std::cout, std::endl
 
 #include "command.h"
+#include "error.h"
 #include "utils.h"
 
 auto sourcemeta::jsonschema::cli::encode(
     const sourcemeta::core::Options &options) -> int {
   if (options.positional().size() < 2) {
-    std::cerr
-        << "error: This command expects a path to a JSON document and an "
-           "output path. For example:\n\n"
-        << "  jsonschema encode path/to/document.json path/to/output.binpack\n";
-    return EXIT_FAILURE;
+    throw sourcemeta::jsonschema::PositionalArgumentError(
+        "This command expects a path to a JSON document and an "
+        "output path. For example:",
+        "  jsonschema encode path/to/document.json path/to/output.binpack");
   }
 
   // TODO: Take a real schema as argument

--- a/src/command_inspect.cc
+++ b/src/command_inspect.cc
@@ -8,6 +8,7 @@
 #include <ostream>  // std::ostream
 
 #include "command.h"
+#include "error.h"
 #include "utils.h"
 
 auto print_frame(std::ostream &stream,
@@ -145,10 +146,9 @@ auto print_frame(std::ostream &stream,
 auto sourcemeta::jsonschema::cli::inspect(
     const sourcemeta::core::Options &options) -> int {
   if (options.positional().size() < 1) {
-    std::cerr
-        << "error: This command expects a path to a schema. For example:\n\n"
-        << "  jsonschema inspect path/to/schema.json\n";
-    return EXIT_FAILURE;
+    throw sourcemeta::jsonschema::PositionalArgumentError(
+        "This command expects a path to a schema. For example:",
+        "  jsonschema inspect path/to/schema.json");
   }
 
   const std::filesystem::path schema_path{options.positional().front()};

--- a/src/command_validate.cc
+++ b/src/command_validate.cc
@@ -15,6 +15,7 @@
 #include <string>   // std::string
 
 #include "command.h"
+#include "error.h"
 #include "utils.h"
 
 namespace {
@@ -129,19 +130,17 @@ auto run_loop(sourcemeta::blaze::Evaluator &evaluator,
 auto sourcemeta::jsonschema::cli::validate(
     const sourcemeta::core::Options &options) -> int {
   if (options.positional().size() < 1) {
-    std::cerr
-        << "error: This command expects a path to a schema and a path to an\n"
-        << "instance to validate against the schema. For example:\n\n"
-        << "  jsonschema validate path/to/schema.json path/to/instance.json\n";
-    return EXIT_FAILURE;
+    throw sourcemeta::jsonschema::PositionalArgumentError(
+        "This command expects a path to a schema and a path to an\n"
+        "instance to validate against the schema. For example:",
+        "  jsonschema validate path/to/schema.json path/to/instance.json");
   }
 
   if (options.positional().size() < 2) {
-    std::cerr
-        << "error: In addition to the schema, you must also pass an argument\n"
-        << "that represents the instance to validate against. For example:\n\n"
-        << "  jsonschema validate path/to/schema.json path/to/instance.json\n";
-    return EXIT_FAILURE;
+    throw sourcemeta::jsonschema::PositionalArgumentError(
+        "In addition to the schema, you must also pass an argument\n"
+        "that represents the instance to validate against. For example:",
+        "  jsonschema validate path/to/schema.json path/to/instance.json");
   }
 
   const auto &schema_path{options.positional().at(0)};

--- a/src/error.h
+++ b/src/error.h
@@ -27,6 +27,19 @@ private:
   std::filesystem::path path_;
 };
 
+class PositionalArgumentError : public std::runtime_error {
+public:
+  PositionalArgumentError(std::string message, std::string example)
+      : std::runtime_error{std::move(message)}, example_{std::move(example)} {}
+
+  [[nodiscard]] auto example() const noexcept -> const std::string & {
+    return example_;
+  }
+
+private:
+  std::string example_;
+};
+
 inline auto try_catch(const std::function<int()> &callback) noexcept -> int {
   try {
     return callback();
@@ -165,6 +178,9 @@ inline auto try_catch(const std::function<int()> &callback) noexcept -> int {
   } catch (const sourcemeta::core::OptionsUnknownOptionError &error) {
     std::cerr << "error: " << error.what() << " '" << error.name() << "'\n";
     std::cerr << "Use '--help' for usage information\n";
+    return EXIT_FAILURE;
+  } catch (const sourcemeta::jsonschema::PositionalArgumentError &error) {
+    std::cerr << "error: " << error.what() << "\n\n" << error.example() << "\n";
     return EXIT_FAILURE;
   } catch (const std::runtime_error &error) {
     std::cerr << "error: " << error.what() << "\n";


### PR DESCRIPTION
This PR introduces a new `PositionalArgumentError` exception in `src/error.h` to centralize error handling logic. Commands no longer directly print positional argument errors.

## Changes

- Added `PositionalArgumentError` class to `src/error.h`
- Added catch handler for `PositionalArgumentError` in `try_catch` function
- Updated all commands that check positional arguments to throw `PositionalArgumentError`:
  - `command_validate.cc` (2 checks)
  - `command_inspect.cc`
  - `command_bundle.cc`
  - `command_compile.cc`
  - `command_decode.cc`
  - `command_encode.cc`

## Testing

- All existing tests pass (301/301)
- Code has been formatted with `make configure compile`

Fixes #507